### PR TITLE
Make it work on Ubuntu 24.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,10 @@ GitHub Actions runs the [build.sh](build.sh) script which turns the [root/](root
 
 ## Use
 
-First make sure the new Ubuntu 22.04 server's IP has access to the NFS `/share`.
+First make sure the new Ubuntu 24.04 server's IP has access to the NFS `/share`.
 
 Then run the included install script. Like this:
+
 ```bash
 curl -sL https://raw.githubusercontent.com/Notifiarr/workers/main/install.sh | sudo bash
 ```
@@ -31,10 +32,10 @@ package, the [install.sh](install.sh) script installs and configures:
 
 - [Notifiarr Client](https://github.com/Notifiarr/notifiarr)
 - [PPA for ondrej/php](https://launchpad.net/~ondrej/+archive/ubuntu/php)
+- [Influx APT Repo](https://docs.influxdata.com/influxdb/v1/introduction/install/#installing-influxdb-oss)
 - NFS `/share` mount
-- [Datadog Agent](https://app.datadoghq.com/account/settings/agent/latest?platform=ubuntu)
 
-# License
+## License
 
-- This software is Copyright 2024 Notifiarr, LLC.
-- Read the [license](LICENSE) if you intend to make copies.
+- This software is Copyright Notifiarr, LLC.
+- Read the [GPLv2 license](LICENSE) if you intend to make copies.

--- a/install.sh
+++ b/install.sh
@@ -1,23 +1,33 @@
 #!/bin/bash
 
-# This is the entry point for setting up a worker. Download and run this script on a fresh Ubuntu 22.04 server.
+# This is the entry point for setting up a worker. Download and run this script on a fresh Ubuntu 24.04 server.
 # Make sure the new server has access to the NFS /share (see below). It's safe to run this more than once; in case you forgot.
 
+echo "==> Adding Public Golift APT repo"
 curl -s https://golift.io/repo.sh | sudo bash -s - notifiarr
 
-echo "Adding Nonpublic Golift APT repo"
-curl -sL https://packagecloud.io/golift/nonpublic/gpgkey | gpg --dearmor > /tmp/golift-nonpublic-keyring.gpg && \
-    sudo mv -f /tmp/golift-nonpublic-keyring.gpg /usr/share/keyrings/golift-nonpublic-keyring.gpg
+echo "==> Adding Nonpublic Golift APT repo"
+curl -sL https://packagecloud.io/golift/nonpublic/gpgkey | gpg --dearmor | \
+    sudo tee /usr/share/keyrings/golift-nonpublic-keyring.gpg > /dev/null
 echo "deb [signed-by=/usr/share/keyrings/golift-nonpublic-keyring.gpg] https://packagecloud.io/golift/nonpublic/ubuntu focal main" | \
-    sudo tee /etc/apt/sources.list.d/golift-nonpublic.list
+    sudo tee /etc/apt/sources.list.d/golift-nonpublic.list > /dev/null
 
+echo "==> Adding Influx/Telegraf APT repo"
+curl -s https://repos.influxdata.com/influxdata-archive.key | gpg --dearmor | \
+    sudo tee /etc/apt/keyrings/influxdata-archive.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/influxdata-archive.gpg] https://repos.influxdata.com/debian stable main" | \
+    sudo tee /etc/apt/sources.list.d/influxdata.list > /dev/null
+
+echo "==> Adding PHP PPA"
 sudo add-apt-repository -y ppa:ondrej/php
 sudo apt install -y notifiarr-worker
 
 if ! grep -q /share /etc/fstab ; then
-    echo "Adding /share mount to /etc/fstab:"
+    echo "==> Adding /share mount to /etc/fstab:"
     echo "10.1.0.92:/volume1/data/share /share nfs rw,noatime,norelatime,async,vers=4.0,rsize=131072,wsize=131072,soft,sec=sys,auto 0 0" | \
         sudo tee -a /etc/fstab
+else
+    echo "==> OK: /share is already in /etc/fstab."
 fi
 
 if [ ! -d /share/workers ]; then
@@ -27,23 +37,9 @@ fi
 
 if [ -f /share/workers/defaults/notifiarr.conf ] && \
         ! diff -s /etc/notifiarr/notifiarr.conf /share/workers/defaults/notifiarr.conf >/dev/null; then
-    echo "Installing notifiarr.conf and restarting the client"
+    echo "==> Installing notifiarr.conf and restarting the client"
     sudo cp /share/workers/defaults/notifiarr.conf /etc/notifiarr/
     sudo systemctl restart notifiarr
-fi
-
-if [ -f /share/workers/defaults/datadog-api-key.txt ] && [ ! -d /etc/datadog-agent ]; then
-    echo "Installing datadog agent."
-    DD_API_KEY=$(head -n1 /share/workers/defaults/datadog-api-key.txt) \
-    DD_SITE="datadoghq.com" \
-    DD_APM_INSTRUMENTATION_ENABLED=host \
-        bash -c "$(curl -L https://s3.amazonaws.com/dd-agent/scripts/install_script_agent7.sh)"
-fi
-
-if [ -d /etc/datadog-agent ] && [ ! -f /etc/datadog-agent/environment ]; then
-    echo "Creating Datadog environment config file: /etc/datadog-agent/environment"
-    echo "DD_PROCESS_AGENT_ENABLED=true"                     | sudo tee    /etc/datadog-agent/environment
-    echo "DD_SYSTEM_PROBE_NETWORK_ENABLED=true"              | sudo tee -a /etc/datadog-agent/environment
-    echo "DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED=true" | sudo tee -a /etc/datadog-agent/environment
-    sudo systemctl restart datadog-agent
+else
+    echo "==> OK: notifiarr.conf is already installed."
 fi

--- a/root/etc/sudoers.d/workers
+++ b/root/etc/sudoers.d/workers
@@ -2,6 +2,7 @@
 # The manager container also has access to run commands listed here.
 # Use DEBIAN_FRONTEND=noninteractive sudo -E for apt upgades.
 abc ALL=(root) NOPASSWD: /usr/bin/systemctl restart supervisor
+abc ALL=(root) NOPASSWD: /usr/bin/systemctl status supervisor
 abc ALL=(root) NOPASSWD: /usr/bin/systemctl start supervisor
 abc ALL=(root) NOPASSWD: /usr/sbin/reboot
 abc ALL=(root) NOPASSWD: /usr/bin/apt update

--- a/root/etc/systemd/system/supervisor.service.d/notifiarr.conf
+++ b/root/etc/systemd/system/supervisor.service.d/notifiarr.conf
@@ -15,4 +15,4 @@ ExecReload=
 ExecReload=/usr/bin/supervisorctl -c /config/supervisor/supervisord.conf $OPTIONS reload
 
 # We need more open files that 1024.
-LimitNOFILE=11000
+LimitNOFILE=65534


### PR DESCRIPTION
- Updates the install script and package to Ubuntu 24.
- Removes datadog.
- Adds Influx APT repo (for Telegraf).